### PR TITLE
fix: snyk pr title rename

### DIFF
--- a/.github/workflows/snyk-pr-format.yml
+++ b/.github/workflows/snyk-pr-format.yml
@@ -10,7 +10,7 @@ jobs:
   format-title:
     name: Reformat Snyk PR title to conventional commits
     runs-on: ubuntu-latest
-    if: github.actor == 'snyk-bot'
+    if: startsWith(github.event.pull_request.title, '[Snyk]')
 
     permissions:
       pull-requests: write


### PR DESCRIPTION
Auto rename Snyk PRs to match conventional commits, our Snyk free subscription does not appear to support custom PR titles.