### PR TITLE
feat(admin): cache RSVP report to Netlify Blobs with autosave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ the task done:
 
 - `pre-commit run --all-files`
 - `npm run build`
+- Verify against the Sonarqube plugin for any fixes that need to be applied. Prompt the user on cognitive complexity fixes.
 
 Fix any failures before considering the work complete.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hcaptcha/react-hcaptcha": "^2.0.0",
         "@hookform/resolvers": "^5.2.1",
         "@monaco-editor/react": "^4.7.0",
+        "@netlify/blobs": "^10.7.12",
         "@octokit/app": "^16.1.0",
         "@octokit/rest": "^22.0.0",
         "@types/nodemailer": "^8.0.0",
@@ -655,6 +656,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -845,6 +859,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
     },
     "node_modules/@hcaptcha/react-hcaptcha": {
       "version": "2.1.0",
@@ -1679,6 +1699,73 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@netlify/blobs": {
+      "version": "10.7.12",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.12.tgz",
+      "integrity": "sha512-4YL/MKu0t+gPeIL+GkqBxYVkqh1612Cgw4J5OaF3XIa3HRH/EMsZ7+cssLOE9i4e2pEAI48+BiehoV30b9xPfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "4.4.7",
+        "@netlify/otel": "^6.0.5",
+        "@netlify/runtime-utils": "2.3.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/dev-utils": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
+      "integrity": "sha512-etfUY5SyraYG+i4msfVnWuFEkia6XLxeoe8Hh5uGO6QJ4OAQT4EmesXjulsI0/7EozMxdiANGnf2AAshn+2jpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.11.0",
+        "ansis": "^4.1.0",
+        "atomically": "^2.0.3",
+        "chokidar": "^4.0.1",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "image-size": "^2.0.2",
+        "js-image-generator": "^1.0.4",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/@netlify/dev-utils/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/otel": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.5.tgz",
+      "integrity": "sha512-FUnQsG+xp5gljmHZgrBgGLYKmKYQlGvrao6gtKenJSPCYTMzsYB9PbFfjIoEvwS+o8DxuWDrHlRDDGU3o9ObhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace-node": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20.6.1"
+      }
+    },
     "node_modules/@netlify/plugin-nextjs": {
       "version": "5.15.13",
       "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.13.tgz",
@@ -1687,6 +1774,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@netlify/runtime-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
+      "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || >=20"
       }
     },
     "node_modules/@next/env": {
@@ -2411,6 +2507,208 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
+      "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.9.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/sdk-trace-base": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@panva/hkdf": {
@@ -3579,6 +3877,75 @@
         "win32"
       ]
     },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+      "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3646,6 +4013,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -3852,6 +4228,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
@@ -4070,6 +4456,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4156,6 +4550,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -4547,6 +4962,15 @@
         }
       }
     },
+    "node_modules/decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0"
+      }
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -4630,6 +5054,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dettle": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
+      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -4729,6 +5159,21 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4757,6 +5202,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -4921,6 +5375,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -6168,6 +6628,18 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6193,6 +6665,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -6718,6 +7204,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-image-generator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
+      "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jpeg-js": "^0.4.2"
       }
     },
     "node_modules/js-tokens": {
@@ -8100,6 +8601,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8569,6 +9076,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8849,6 +9365,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8998,6 +9527,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -9276,7 +9818,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9741,6 +10282,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -9836,6 +10392,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9936,6 +10510,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -10257,6 +10843,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10314,6 +10906,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@octokit/rest": "^22.0.0",
         "@types/nodemailer": "^8.0.0",
         "gray-matter": "^4.0.3",
+        "image-size": "^2.0.2",
         "js-yaml": "^5.0.0",
         "next": "^16.2.11",
         "next-auth": "^4.24.11",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@hcaptcha/react-hcaptcha": "^2.0.0",
     "@hookform/resolvers": "^5.2.1",
     "@monaco-editor/react": "^4.7.0",
+    "@netlify/blobs": "^10.7.12",
     "@octokit/app": "^16.1.0",
     "@octokit/rest": "^22.0.0",
     "@types/nodemailer": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@octokit/rest": "^22.0.0",
     "@types/nodemailer": "^8.0.0",
     "gray-matter": "^4.0.3",
+    "image-size": "^2.0.2",
     "js-yaml": "^5.0.0",
     "next": "^16.2.11",
     "next-auth": "^4.24.11",

--- a/src/app/admin/posts/[slug]/rsvps/page.tsx
+++ b/src/app/admin/posts/[slug]/rsvps/page.tsx
@@ -222,6 +222,10 @@ function SortableHeaderCell({
   onSort: (column: SortColumn) => void;
 }>) {
   const isActive = activeColumn === column;
+  let indicator = "";
+  if (isActive) {
+    indicator = direction === "asc" ? "▲" : "▼";
+  }
   return (
     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
       <button
@@ -231,7 +235,7 @@ function SortableHeaderCell({
       >
         {label}
         <span className="inline-block w-3 text-[10px] normal-case">
-          {isActive ? (direction === "asc" ? "▲" : "▼") : ""}
+          {indicator}
         </span>
       </button>
     </th>
@@ -651,7 +655,7 @@ export default function RsvpReportPage() {
   const availableSources = useMemo(() => {
     const sources = new Set<string>();
     tableRows.forEach((row) => row.sources.forEach((s) => sources.add(s)));
-    return Array.from(sources).sort();
+    return Array.from(sources).sort((a, b) => a.localeCompare(b));
   }, [tableRows]);
 
   const filteredRows = useMemo(() => {
@@ -715,7 +719,7 @@ export default function RsvpReportPage() {
   };
 
   const escapeCsvField = (value: string): string =>
-    /["\r\n,]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+    /["\r\n,]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value;
 
   // Client-side only, same as the CSV upload above - nothing is sent
   // anywhere. One row per person (or per estimated walk-in) so the file
@@ -751,9 +755,26 @@ export default function RsvpReportPage() {
       .slice(0, 10)}.csv`;
     document.body.appendChild(link);
     link.click();
-    document.body.removeChild(link);
+    link.remove();
     URL.revokeObjectURL(url);
   };
+
+  let loadingStatus: React.ReactNode;
+  if (isLoadingCache) {
+    loadingStatus = (
+      <>
+        <InlineSpinner /> Checking for a cached report…
+      </>
+    );
+  } else if (pendingSources.length > 0) {
+    loadingStatus = (
+      <>
+        <InlineSpinner /> Loading: {pendingSources.join(", ")}…
+      </>
+    );
+  } else {
+    loadingStatus = "All sources loaded.";
+  }
 
   return (
     <div className="space-y-6">
@@ -802,17 +823,7 @@ export default function RsvpReportPage() {
         </p>
         {isMounted && (
           <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            {isLoadingCache ? (
-              <>
-                <InlineSpinner /> Checking for a cached report…
-              </>
-            ) : pendingSources.length > 0 ? (
-              <>
-                <InlineSpinner /> Loading: {pendingSources.join(", ")}…
-              </>
-            ) : (
-              "All sources loaded."
-            )}
+            {loadingStatus}
             {!isLoadingCache && cachedAt && (
               <span className="ml-2">
                 Cached report from {formatTimestamp(cachedAt)}.
@@ -844,12 +855,9 @@ export default function RsvpReportPage() {
       </div>
 
       {saveNotification && (
-        <div
-          role="status"
-          className="fixed bottom-4 right-4 z-50 rounded-md bg-gray-900 dark:bg-gray-700 px-4 py-2 text-sm text-white shadow-lg"
-        >
+        <output className="fixed bottom-4 right-4 z-50 rounded-md bg-gray-900 dark:bg-gray-700 px-4 py-2 text-sm text-white shadow-lg">
           {saveNotification}
-        </div>
+        </output>
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">

--- a/src/app/admin/posts/[slug]/rsvps/page.tsx
+++ b/src/app/admin/posts/[slug]/rsvps/page.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { clusterEntriesByName, type NamedEntry } from "@/lib/name-matching";
+import {
+  clusterEntriesByName,
+  type EntryCluster,
+  type NamedEntry,
+} from "@/lib/name-matching";
 
 interface SheetRsvpRow {
   firstName: string;
@@ -167,10 +171,70 @@ function parseAttendeesCsv(text: string): CsvAttendee[] {
 const SOURCE_SHEET = "Google Sheet";
 const SOURCE_MEETUP = "Meetup";
 const SOURCE_CSV = "Meetup (CSV export)";
+const SOURCE_MANUAL = "Manual estimate";
+
+type SortColumn = "name" | "source" | "timestamp" | "comments";
+
+type TableRow =
+  | {
+      kind: "cluster";
+      key: string;
+      name: string;
+      sources: string[];
+      timestamp?: string;
+      comments: string;
+      cluster: EntryCluster;
+    }
+  | { kind: "unnamedMeetup"; key: string; name: string; sources: string[] }
+  | { kind: "manualEstimate"; key: string; name: string; sources: string[] };
+
+// How long the report must sit unchanged before it's auto-saved to the
+// Netlify Blobs cache.
+const AUTOSAVE_DELAY_MS = 10000;
+
+interface CachedReportData {
+  sheetData: SheetData | null;
+  meetupData: MeetupData | null;
+  csvAttendees: CsvAttendee[];
+  csvFileName: string | null;
+  manualEstimate: number;
+  dedupeEnabled: boolean;
+  confidenceThreshold: number;
+}
 
 function InlineSpinner() {
   return (
     <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-etsa-primary align-[-2px]" />
+  );
+}
+
+function SortableHeaderCell({
+  label,
+  column,
+  activeColumn,
+  direction,
+  onSort,
+}: Readonly<{
+  label: string;
+  column: SortColumn;
+  activeColumn: SortColumn;
+  direction: "asc" | "desc";
+  onSort: (column: SortColumn) => void;
+}>) {
+  const isActive = activeColumn === column;
+  return (
+    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        className="flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-200"
+      >
+        {label}
+        <span className="inline-block w-3 text-[10px] normal-case">
+          {isActive ? (direction === "asc" ? "▲" : "▼") : ""}
+        </span>
+      </button>
+    </th>
   );
 }
 
@@ -205,6 +269,25 @@ export default function RsvpReportPage() {
     prUrl?: string;
   } | null>(null);
 
+  // Cached-report state: loaded once on mount from Netlify Blobs, then
+  // auto-saved back after AUTOSAVE_DELAY_MS of no further edits.
+  const [isLoadingCache, setIsLoadingCache] = useState(true);
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSavingReport, setIsSavingReport] = useState(false);
+  const [saveNotification, setSaveNotification] = useState<string | null>(null);
+  const [autosaveDeadline, setAutosaveDeadline] = useState<number | null>(null);
+  const [secondsUntilAutosave, setSecondsUntilAutosave] = useState<
+    number | null
+  >(null);
+
+  // Table view state - filtering/sorting is presentation-only, not part of
+  // the cached report.
+  const [tableFilterText, setTableFilterText] = useState("");
+  const [tableSourceFilter, setTableSourceFilter] = useState("all");
+  const [sortColumn, setSortColumn] = useState<SortColumn>("name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+
   // Loading text below depends on client-only state (which source is still
   // pending) - gate it behind mount so the server-rendered HTML and the
   // first client render match, then swap in the real status after hydration.
@@ -229,6 +312,7 @@ export default function RsvpReportPage() {
       if (!response.ok) throw new Error("Failed to load Meetup RSVPs");
       const data = await response.json();
       setMeetupData(data);
+      setIsDirty(true);
     } catch (err) {
       setMeetupLoadError("Failed to load Meetup RSVPs.");
       console.error("Error querying manual Meetup Event ID:", err);
@@ -284,8 +368,9 @@ export default function RsvpReportPage() {
 
   // Sheet and Meetup are fetched independently (separate API routes) so the
   // page can show which one is still loading instead of one opaque spinner
-  // gating everything until both are done.
-  useEffect(() => {
+  // gating everything until both are done. Marks the report dirty once both
+  // land, so a fresh pull from sources gets auto-saved back to the cache.
+  const loadFromSources = () => {
     if (!slug) return;
 
     setIsSheetLoading(true);
@@ -300,7 +385,10 @@ export default function RsvpReportPage() {
         setSheetLoadError("Failed to load Google Sheet RSVPs.");
         console.error("Error loading Sheet RSVPs:", err);
       })
-      .finally(() => setIsSheetLoading(false));
+      .finally(() => {
+        setIsSheetLoading(false);
+        setIsDirty(true);
+      });
 
     setIsMeetupLoading(true);
     setMeetupLoadError(null);
@@ -314,8 +402,134 @@ export default function RsvpReportPage() {
         setMeetupLoadError("Failed to load Meetup RSVPs.");
         console.error("Error loading Meetup RSVPs:", err);
       })
-      .finally(() => setIsMeetupLoading(false));
+      .finally(() => {
+        setIsMeetupLoading(false);
+        setIsDirty(true);
+      });
+  };
+
+  // On mount, look for a cached report before hitting Sheet/Meetup live -
+  // the cache is the fast path, live sources are only pulled when there's
+  // nothing cached yet or the user explicitly asks for a refresh.
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+
+    (async () => {
+      setIsLoadingCache(true);
+      try {
+        const response = await fetch(`/api/admin/posts/${slug}/rsvps/cache`);
+        if (response.ok) {
+          const { cached } = await response.json();
+          if (cached && !cancelled) {
+            const data = cached.data as CachedReportData;
+            setSheetData(data.sheetData ?? null);
+            setMeetupData(data.meetupData ?? null);
+            setCsvAttendees(data.csvAttendees ?? []);
+            setCsvFileName(data.csvFileName ?? null);
+            setManualEstimate(data.manualEstimate ?? 0);
+            setDedupeEnabled(data.dedupeEnabled ?? true);
+            setConfidenceThreshold(data.confidenceThreshold ?? 0.9);
+            setCachedAt(cached.savedAt);
+            setIsSheetLoading(false);
+            setIsMeetupLoading(false);
+            setIsLoadingCache(false);
+            return;
+          }
+        }
+      } catch (err) {
+        console.error("Error loading cached RSVP report:", err);
+      }
+      if (!cancelled) {
+        setIsLoadingCache(false);
+        loadFromSources();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug]);
+
+  const saveReport = async () => {
+    if (!slug) return;
+    setIsSavingReport(true);
+    try {
+      const payload: CachedReportData = {
+        sheetData,
+        meetupData,
+        csvAttendees,
+        csvFileName,
+        manualEstimate,
+        dedupeEnabled,
+        confidenceThreshold,
+      };
+      const response = await fetch(`/api/admin/posts/${slug}/rsvps/cache`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error("Failed to save report");
+      const { cached } = await response.json();
+      setCachedAt(cached.savedAt);
+      setIsDirty(false);
+      setSaveNotification("Report saved.");
+    } catch (err) {
+      console.error("Error saving RSVP report:", err);
+      setSaveNotification("Failed to save report.");
+    } finally {
+      setIsSavingReport(false);
+    }
+  };
+
+  // Auto-save once the report has sat unchanged for AUTOSAVE_DELAY_MS - any
+  // further edit resets this timer via the dependency array below.
+  useEffect(() => {
+    if (!isDirty || isLoadingCache) {
+      setAutosaveDeadline(null);
+      return;
+    }
+    setAutosaveDeadline(Date.now() + AUTOSAVE_DELAY_MS);
+    const timer = setTimeout(() => {
+      saveReport();
+    }, AUTOSAVE_DELAY_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isDirty,
+    isLoadingCache,
+    sheetData,
+    meetupData,
+    csvAttendees,
+    csvFileName,
+    manualEstimate,
+    dedupeEnabled,
+    confidenceThreshold,
+  ]);
+
+  // Ticks the "saving in Ns" countdown shown next to "Unsaved changes." -
+  // purely cosmetic, doesn't drive the actual save (the timer above does).
+  useEffect(() => {
+    if (autosaveDeadline === null) {
+      setSecondsUntilAutosave(null);
+      return;
+    }
+    const update = () => {
+      setSecondsUntilAutosave(
+        Math.max(0, Math.ceil((autosaveDeadline - Date.now()) / 1000)),
+      );
+    };
+    update();
+    const interval = setInterval(update, 250);
+    return () => clearInterval(interval);
+  }, [autosaveDeadline]);
+
+  useEffect(() => {
+    if (!saveNotification) return;
+    const timer = setTimeout(() => setSaveNotification(null), 4000);
+    return () => clearTimeout(timer);
+  }, [saveNotification]);
 
   const handleCsvUpload = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -332,6 +546,7 @@ export default function RsvpReportPage() {
         ? "Couldn't find a name column in this CSV - check that it's the guest list export from the Meetup event dashboard."
         : null,
     );
+    setIsDirty(true);
   };
 
   const postTitle = sheetData?.postTitle || meetupData?.postTitle || "";
@@ -397,6 +612,149 @@ export default function RsvpReportPage() {
     isMeetupLoading && "Meetup",
   ].filter((source): source is string => Boolean(source));
 
+  // One row per line in the table below - named clusters plus the two
+  // aggregate "no identity" rows, unified so filtering/sorting can treat
+  // them the same way.
+  const tableRows = useMemo<TableRow[]>(() => {
+    const rows: TableRow[] = displayClusters.map((cluster) => ({
+      kind: "cluster",
+      key: cluster.mergedFrom.map((e) => e.id).join("|"),
+      name: cluster.name,
+      sources: cluster.sources,
+      timestamp: cluster.timestamp,
+      comments: cluster.primaryEntry.comments || "",
+      cluster,
+    }));
+    if (unnamedMeetupCount > 0) {
+      rows.push({
+        kind: "unnamedMeetup",
+        key: "unnamed-meetup",
+        name: `${unnamedMeetupCount} additional Meetup RSVP${
+          unnamedMeetupCount === 1 ? "" : "s"
+        } (names not available)`,
+        sources: [SOURCE_MEETUP],
+      });
+    }
+    if (manualEstimate > 0) {
+      rows.push({
+        kind: "manualEstimate",
+        key: "manual-estimate",
+        name: `${manualEstimate} estimated walk-in${
+          manualEstimate === 1 ? "" : "s"
+        }`,
+        sources: [SOURCE_MANUAL],
+      });
+    }
+    return rows;
+  }, [displayClusters, unnamedMeetupCount, manualEstimate]);
+
+  const availableSources = useMemo(() => {
+    const sources = new Set<string>();
+    tableRows.forEach((row) => row.sources.forEach((s) => sources.add(s)));
+    return Array.from(sources).sort();
+  }, [tableRows]);
+
+  const filteredRows = useMemo(() => {
+    const needle = tableFilterText.trim().toLowerCase();
+    return tableRows.filter((row) => {
+      if (
+        tableSourceFilter !== "all" &&
+        !row.sources.includes(tableSourceFilter)
+      ) {
+        return false;
+      }
+      if (!needle) return true;
+      const comments = row.kind === "cluster" ? row.comments : "";
+      const haystack = `${row.name} ${row.sources.join(
+        " ",
+      )} ${comments}`.toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [tableRows, tableFilterText, tableSourceFilter]);
+
+  const sortedRows = useMemo(() => {
+    const sortValue = (row: TableRow): string => {
+      switch (sortColumn) {
+        case "name":
+          return row.name;
+        case "source":
+          return row.sources.join(", ");
+        case "comments":
+          return row.kind === "cluster" ? row.comments : "";
+        case "timestamp":
+          return "";
+      }
+    };
+    const sorted = [...filteredRows].sort((a, b) => {
+      if (sortColumn === "timestamp") {
+        const aTime =
+          a.kind === "cluster" && a.timestamp
+            ? new Date(a.timestamp).getTime()
+            : null;
+        const bTime =
+          b.kind === "cluster" && b.timestamp
+            ? new Date(b.timestamp).getTime()
+            : null;
+        if (aTime === null && bTime === null) return 0;
+        if (aTime === null) return 1;
+        if (bTime === null) return -1;
+        return aTime - bTime;
+      }
+      return sortValue(a).localeCompare(sortValue(b));
+    });
+    return sortDirection === "asc" ? sorted : sorted.reverse();
+  }, [filteredRows, sortColumn, sortDirection]);
+
+  const toggleSort = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc");
+    }
+  };
+
+  const escapeCsvField = (value: string): string =>
+    /["\r\n,]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+
+  // Client-side only, same as the CSV upload above - nothing is sent
+  // anywhere. One row per person (or per estimated walk-in) so the file
+  // stays tabular - no aggregate/summary rows that would break parsing.
+  const downloadCsvReport = () => {
+    const rows: string[][] = [
+      ["Name", "Source", "RSVP'd", "Comments and/or questions"],
+    ];
+    displayClusters.forEach((cluster) => {
+      rows.push([
+        cluster.name,
+        cluster.sources.join(", "),
+        formatTimestamp(cluster.timestamp),
+        cluster.primaryEntry.comments || "",
+      ]);
+    });
+    for (let i = 0; i < unnamedMeetupCount; i++) {
+      rows.push(["Meetup RSVP (name not available)", "Meetup", "", ""]);
+    }
+    for (let i = 0; i < manualEstimate; i++) {
+      rows.push(["Estimated walk-in", "Manual estimate", "", ""]);
+    }
+
+    const csvText = rows
+      .map((row) => row.map(escapeCsvField).join(","))
+      .join("\r\n");
+    const blob = new Blob([csvText], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `rsvp-report-${slug}-${new Date()
+      .toISOString()
+      .slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -406,22 +764,70 @@ export default function RsvpReportPage() {
         >
           &larr; Back to Posts
         </Link>
-        <h1 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white">
-          RSVP Report{postTitle ? `: ${postTitle}` : ""}
-        </h1>
+        <div className="mt-2 flex flex-wrap items-start justify-between gap-3">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            RSVP Report{postTitle ? `: ${postTitle}` : ""}
+          </h1>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={isLoadingCache || isAnythingLoading}
+              onClick={loadFromSources}
+              className="text-sm px-3 py-1.5 rounded-md border border-etsa-primary text-etsa-primary hover:bg-etsa-primary/10 disabled:opacity-50"
+            >
+              Refresh from data sources
+            </button>
+            <button
+              type="button"
+              disabled={isLoadingCache || isSavingReport}
+              onClick={saveReport}
+              className="text-sm px-3 py-1.5 rounded-md border border-etsa-primary text-etsa-primary hover:bg-etsa-primary/10 disabled:opacity-50"
+            >
+              {isSavingReport ? "Saving..." : "Save now"}
+            </button>
+            <button
+              type="button"
+              onClick={downloadCsvReport}
+              className="text-sm px-3 py-1.5 rounded-md bg-etsa-primary text-white hover:bg-etsa-primary-dark"
+            >
+              Download CSV report
+            </button>
+          </div>
+        </div>
         <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
           Combines RSVPs from the site&apos;s Google Sheet, Meetup, an uploaded
-          Meetup guest-list CSV, and a manual walk-in estimate. Nothing on this
-          page is saved - re-open it fresh each time you need the number.
+          Meetup guest-list CSV, and a manual walk-in estimate. Loads the last
+          saved report automatically, then auto-saves back to the cache{" "}
+          {AUTOSAVE_DELAY_MS / 1000} seconds after you stop making changes.
         </p>
         {isMounted && (
           <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            {pendingSources.length > 0 ? (
+            {isLoadingCache ? (
+              <>
+                <InlineSpinner /> Checking for a cached report…
+              </>
+            ) : pendingSources.length > 0 ? (
               <>
                 <InlineSpinner /> Loading: {pendingSources.join(", ")}…
               </>
             ) : (
               "All sources loaded."
+            )}
+            {!isLoadingCache && cachedAt && (
+              <span className="ml-2">
+                Cached report from {formatTimestamp(cachedAt)}.
+              </span>
+            )}
+            {isSavingReport && (
+              <span className="ml-2">
+                <InlineSpinner /> Saving report…
+              </span>
+            )}
+            {isDirty && !isSavingReport && (
+              <span className="ml-2">
+                Unsaved changes - autosaving in{" "}
+                {secondsUntilAutosave ?? AUTOSAVE_DELAY_MS / 1000}s.
+              </span>
             )}
             {sheetLoadError && (
               <span className="ml-2 text-red-600 dark:text-red-400">
@@ -436,6 +842,15 @@ export default function RsvpReportPage() {
           </p>
         )}
       </div>
+
+      {saveNotification && (
+        <div
+          role="status"
+          className="fixed bottom-4 right-4 z-50 rounded-md bg-gray-900 dark:bg-gray-700 px-4 py-2 text-sm text-white shadow-lg"
+        >
+          {saveNotification}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
@@ -673,9 +1088,10 @@ export default function RsvpReportPage() {
             type="number"
             min={0}
             value={manualEstimate}
-            onChange={(e) =>
-              setManualEstimate(Math.max(0, Number(e.target.value) || 0))
-            }
+            onChange={(e) => {
+              setManualEstimate(Math.max(0, Number(e.target.value) || 0));
+              setIsDirty(true);
+            }}
             className="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm focus:border-etsa-primary focus:ring-etsa-primary sm:text-sm"
           />
         </div>
@@ -686,7 +1102,10 @@ export default function RsvpReportPage() {
               id="dedupeEnabled"
               type="checkbox"
               checked={dedupeEnabled}
-              onChange={(e) => setDedupeEnabled(e.target.checked)}
+              onChange={(e) => {
+                setDedupeEnabled(e.target.checked);
+                setIsDirty(true);
+              }}
               className="h-4 w-4 rounded border-gray-300 text-etsa-primary focus:ring-etsa-primary"
             />
             <label
@@ -718,7 +1137,10 @@ export default function RsvpReportPage() {
                 max={1}
                 step={0.01}
                 value={confidenceThreshold}
-                onChange={(e) => setConfidenceThreshold(Number(e.target.value))}
+                onChange={(e) => {
+                  setConfidenceThreshold(Number(e.target.value));
+                  setIsDirty(true);
+                }}
                 className="mt-1 block w-full max-w-xs"
               />
             </div>
@@ -726,117 +1148,187 @@ export default function RsvpReportPage() {
         </div>
       </div>
 
+      <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4 flex flex-wrap items-end gap-3">
+        <div className="flex-1 min-w-[200px]">
+          <label
+            htmlFor="tableFilterText"
+            className="block text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            Filter
+          </label>
+          <input
+            id="tableFilterText"
+            type="text"
+            value={tableFilterText}
+            onChange={(e) => setTableFilterText(e.target.value)}
+            placeholder="Search name, source, or comments"
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm focus:border-etsa-primary focus:ring-etsa-primary text-sm"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="tableSourceFilter"
+            className="block text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            Source
+          </label>
+          <select
+            id="tableSourceFilter"
+            value={tableSourceFilter}
+            onChange={(e) => setTableSourceFilter(e.target.value)}
+            className="mt-1 block rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm focus:border-etsa-primary focus:ring-etsa-primary text-sm"
+          >
+            <option value="all">All sources</option>
+            {availableSources.map((source) => (
+              <option key={source} value={source}>
+                {source}
+              </option>
+            ))}
+          </select>
+        </div>
+        {(tableFilterText || tableSourceFilter !== "all") && (
+          <button
+            type="button"
+            onClick={() => {
+              setTableFilterText("");
+              setTableSourceFilter("all");
+            }}
+            className="text-sm text-etsa-primary hover:text-etsa-primary-dark"
+          >
+            Clear filters
+          </button>
+        )}
+        <p className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+          Showing {sortedRows.length} of {tableRows.length}
+        </p>
+      </div>
+
       <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                Name
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                Source
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                RSVP&apos;d
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                Comments and/or questions
-              </th>
+              <SortableHeaderCell
+                label="Name"
+                column="name"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onSort={toggleSort}
+              />
+              <SortableHeaderCell
+                label="Source"
+                column="source"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onSort={toggleSort}
+              />
+              <SortableHeaderCell
+                label="RSVP'd"
+                column="timestamp"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onSort={toggleSort}
+              />
+              <SortableHeaderCell
+                label="Comments and/or questions"
+                column="comments"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onSort={toggleSort}
+              />
             </tr>
           </thead>
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {displayClusters.map((cluster) => (
-              <tr key={cluster.mergedFrom.map((e) => e.id).join("|")}>
-                <td className="px-6 py-3 text-sm text-gray-900 dark:text-white">
-                  {cluster.name}
-                  {cluster.mergedFrom.length > 1 && (
-                    <span className="block text-xs text-gray-400 dark:text-gray-500">
-                      also matched:{" "}
-                      {cluster.mergedFrom
-                        .filter((e) => e !== cluster.primaryEntry)
-                        .map((e) =>
-                          e.name === cluster.primaryEntry.name
-                            ? `duplicate (${e.source})`
-                            : `${e.name} (${e.source})`,
-                        )
-                        .join(", ")}
-                    </span>
-                  )}
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  {cluster.sources.join(", ")}
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  {formatTimestamp(cluster.timestamp)}
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  {cluster.primaryEntry.comments || "—"}
-                </td>
-              </tr>
-            ))}
-            {unnamedMeetupCount > 0 && (
-              <tr>
-                <td className="px-6 py-3 text-sm text-gray-900 dark:text-white italic">
-                  {meetup?.attendeesUrl ? (
-                    <a
-                      href={meetup.attendeesUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="not-italic text-etsa-primary hover:text-etsa-primary-dark underline"
-                    >
-                      {unnamedMeetupCount} additional Meetup RSVP
-                      {unnamedMeetupCount === 1 ? "" : "s"} (names not
-                      available)
-                    </a>
-                  ) : (
-                    <>
-                      {unnamedMeetupCount} additional Meetup RSVP
-                      {unnamedMeetupCount === 1 ? "" : "s"} (names not
-                      available)
-                    </>
-                  )}
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  Meetup
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  —
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  —
-                </td>
-              </tr>
-            )}
-            {manualEstimate > 0 && (
-              <tr>
-                <td className="px-6 py-3 text-sm text-gray-900 dark:text-white italic">
-                  {manualEstimate} estimated walk-in
-                  {manualEstimate === 1 ? "" : "s"}
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  Manual estimate
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  —
-                </td>
-                <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
-                  —
-                </td>
-              </tr>
-            )}
-            {displayClusters.length === 0 &&
-              unnamedMeetupCount === 0 &&
-              manualEstimate === 0 &&
-              !isAnythingLoading && (
-                <tr>
-                  <td
-                    colSpan={4}
-                    className="px-6 py-6 text-sm text-center text-gray-500 dark:text-gray-400"
-                  >
-                    No RSVPs yet from any source.
+            {sortedRows.map((row) => {
+              if (row.kind === "cluster") {
+                const cluster = row.cluster;
+                return (
+                  <tr key={row.key}>
+                    <td className="px-6 py-3 text-sm text-gray-900 dark:text-white">
+                      {cluster.name}
+                      {cluster.mergedFrom.length > 1 && (
+                        <span className="block text-xs text-gray-400 dark:text-gray-500">
+                          also matched:{" "}
+                          {cluster.mergedFrom
+                            .filter((e) => e !== cluster.primaryEntry)
+                            .map((e) =>
+                              e.name === cluster.primaryEntry.name
+                                ? `duplicate (${e.source})`
+                                : `${e.name} (${e.source})`,
+                            )
+                            .join(", ")}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      {cluster.sources.join(", ")}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      {formatTimestamp(cluster.timestamp)}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      {cluster.primaryEntry.comments || "—"}
+                    </td>
+                  </tr>
+                );
+              }
+              if (row.kind === "unnamedMeetup") {
+                return (
+                  <tr key={row.key}>
+                    <td className="px-6 py-3 text-sm text-gray-900 dark:text-white italic">
+                      {meetup?.attendeesUrl ? (
+                        <a
+                          href={meetup.attendeesUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="not-italic text-etsa-primary hover:text-etsa-primary-dark underline"
+                        >
+                          {row.name}
+                        </a>
+                      ) : (
+                        row.name
+                      )}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      {SOURCE_MEETUP}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      —
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                      —
+                    </td>
+                  </tr>
+                );
+              }
+              return (
+                <tr key={row.key}>
+                  <td className="px-6 py-3 text-sm text-gray-900 dark:text-white italic">
+                    {row.name}
+                  </td>
+                  <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    {SOURCE_MANUAL}
+                  </td>
+                  <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    —
+                  </td>
+                  <td className="px-6 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    —
                   </td>
                 </tr>
-              )}
+              );
+            })}
+            {sortedRows.length === 0 && !isAnythingLoading && (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-6 py-6 text-sm text-center text-gray-500 dark:text-gray-400"
+                >
+                  {tableRows.length === 0
+                    ? "No RSVPs yet from any source."
+                    : "No rows match the current filter."}
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/app/api/admin/posts/[slug]/rsvps/cache/route.ts
+++ b/src/app/api/admin/posts/[slug]/rsvps/cache/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { isAuthorizedUser } from "@/lib/auth-utils";
+import { getCachedRsvpReport, saveCachedRsvpReport } from "@/lib/rsvp-cache";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!isAuthorizedUser(session)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const cached = await getCachedRsvpReport(slug);
+    return NextResponse.json({ cached });
+  } catch (error) {
+    console.error("Error loading cached RSVP report:", error);
+    return NextResponse.json(
+      { error: "Failed to load cached RSVP report" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!isAuthorizedUser(session)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const data = await request.json();
+    const cached = await saveCachedRsvpReport(
+      slug,
+      data,
+      session?.user?.email ?? null,
+    );
+    return NextResponse.json({ cached });
+  } catch (error) {
+    console.error("Error saving cached RSVP report:", error);
+    return NextResponse.json(
+      { error: "Failed to save cached RSVP report" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/rsvp-cache.ts
+++ b/src/lib/rsvp-cache.ts
@@ -1,0 +1,39 @@
+import "server-only";
+import { getStore } from "@netlify/blobs";
+
+// One Netlify Blobs store, one key per post slug. Report contents are
+// opaque to this layer - the admin UI owns the shape of `data`.
+const STORE_NAME = "rsvp-reports";
+
+export interface CachedRsvpReport {
+  data: unknown;
+  savedAt: string;
+  savedBy: string | null;
+}
+
+function getRsvpCacheStore() {
+  return getStore(STORE_NAME);
+}
+
+export async function getCachedRsvpReport(
+  slug: string,
+): Promise<CachedRsvpReport | null> {
+  const store = getRsvpCacheStore();
+  const cached = await store.get(slug, { type: "json" });
+  return (cached as CachedRsvpReport | null) ?? null;
+}
+
+export async function saveCachedRsvpReport(
+  slug: string,
+  data: unknown,
+  savedBy: string | null,
+): Promise<CachedRsvpReport> {
+  const store = getRsvpCacheStore();
+  const report: CachedRsvpReport = {
+    data,
+    savedAt: new Date().toISOString(),
+    savedBy,
+  };
+  await store.setJSON(slug, report);
+  return report;
+}


### PR DESCRIPTION
## Summary
- Admin RSVP report page now loads the last-saved report from Netlify Blobs on open instead of re-pulling Google Sheet + Meetup live every time.
- Adds a "Refresh from data sources" button to pull live data on demand, and a "Save now" button for a manual save.
- Auto-saves back to the cache 10s after the report stops changing, with a live "saving in Ns" countdown and a toast notification once saved.
- Adds a "Download CSV report" button - one row per person/estimated walk-in, no aggregate summary rows.
- The RSVP results table is now sortable (click any column header) and filterable (text search + source dropdown).

## New files
- `src/lib/rsvp-cache.ts` - thin `@netlify/blobs` wrapper, one site-scoped store (`rsvp-reports`), one key per post slug.
- `src/app/api/admin/posts/[slug]/rsvps/cache/route.ts` - `GET`/`PUT`, gated by the same admin auth check as the other RSVP routes.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `npm run build`
- [ ] Open `/admin/posts/<slug>/rsvps` on a deployed preview and confirm: cache-miss falls back to live sources, editing triggers the countdown/autosave, "Save now" saves immediately, "Refresh from data sources" repulls live data, CSV downloads correctly, and table sort/filter work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)