### PR TITLE
fix: prevent duplicate attendance records for the same post

### DIFF
--- a/src/app/api/admin/attendance/__tests__/route.test.ts
+++ b/src/app/api/admin/attendance/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { isAuthorizedUser } from "@/lib/auth-utils";
 import { isAttendanceSheetsConfigured } from "@/lib/attendance-sheets-sync";
 import {
+  getAttendanceRecordByPostSlug,
   listAttendanceRecords,
   saveAttendanceRecord,
 } from "@/lib/attendance-store";
@@ -15,6 +16,7 @@ jest.mock("@/lib/attendance-sheets-sync", () => ({
   isAttendanceSheetsConfigured: jest.fn(),
 }));
 jest.mock("@/lib/attendance-store", () => ({
+  getAttendanceRecordByPostSlug: jest.fn(),
   listAttendanceRecords: jest.fn(),
   saveAttendanceRecord: jest.fn(),
 }));
@@ -24,6 +26,9 @@ const mockedGetServerSession = jest.mocked(getServerSession);
 const mockedIsAuthorizedUser = jest.mocked(isAuthorizedUser);
 const mockedIsAttendanceSheetsConfigured = jest.mocked(
   isAttendanceSheetsConfigured,
+);
+const mockedGetAttendanceRecordByPostSlug = jest.mocked(
+  getAttendanceRecordByPostSlug,
 );
 const mockedListAttendanceRecords = jest.mocked(listAttendanceRecords);
 const mockedSaveAttendanceRecord = jest.mocked(saveAttendanceRecord);
@@ -51,6 +56,7 @@ beforeEach(() => {
   } as never);
   mockedIsAuthorizedUser.mockReturnValue(true);
   mockedIsAttendanceSheetsConfigured.mockReturnValue(false);
+  mockedGetAttendanceRecordByPostSlug.mockResolvedValue(null);
 });
 
 afterEach(() => jest.clearAllMocks());
@@ -101,6 +107,30 @@ describe("POST /api/admin/attendance", () => {
         ...validInput,
         updatedBy: "board@etsa.tech",
       }),
+    );
+  });
+
+  it("updates the existing record instead of creating a duplicate when a record for the postSlug already exists", async () => {
+    const existing = {
+      id: "existing-id",
+      ...validInput,
+      inPersonCount: 1,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+      updatedBy: null,
+    };
+    mockedGetAttendanceRecordByPostSlug.mockResolvedValue(existing as never);
+    mockedSaveAttendanceRecord.mockResolvedValue({
+      record: { ...existing, ...validInput } as never,
+    });
+
+    const res = await POST(postReq(validInput));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.record.id).toBe("existing-id");
+    expect(mockedSaveAttendanceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "existing-id", ...validInput }),
+      existing,
     );
   });
 

--- a/src/app/api/admin/attendance/route.ts
+++ b/src/app/api/admin/attendance/route.ts
@@ -6,6 +6,7 @@ import { isAuthorizedUser } from "@/lib/auth-utils";
 import { isAttendanceSheetsConfigured } from "@/lib/attendance-sheets-sync";
 import { validateAttendanceRecordInput } from "@/lib/validation";
 import {
+  getAttendanceRecordByPostSlug,
   listAttendanceRecords,
   saveAttendanceRecord,
 } from "@/lib/attendance-store";
@@ -53,6 +54,29 @@ export async function POST(request: NextRequest) {
 
   try {
     const now = new Date().toISOString();
+
+    // At most one record is expected per post (see getAttendanceRecordByPostSlug) -
+    // enforce that server-side too, not just via the bulk-import UI's dedup, so a
+    // stale client (e.g. a second import run before the record list reloads) can't
+    // create a duplicate for the same event.
+    const existing = await getAttendanceRecordByPostSlug(
+      validation.data.postSlug,
+    );
+
+    if (existing) {
+      const { record } = await saveAttendanceRecord(
+        {
+          ...existing,
+          ...validation.data,
+          updatedAt: now,
+          updatedBy: session!.user?.email ?? null,
+        },
+        existing,
+      );
+
+      return NextResponse.json({ record });
+    }
+
     const { record } = await saveAttendanceRecord({
       id: randomUUID(),
       ...validation.data,


### PR DESCRIPTION
## Summary
- Bulk-importing attendance records could create a duplicate record for an event that already has one, because dedup was only enforced client-side (`AttendanceBulkImport`'s `existingRecords` snapshot), while `POST /api/admin/attendance` had no server-side check and records are keyed by a random UUID rather than `postSlug`.
- `POST /api/admin/attendance` now looks up any existing record for the submitted `postSlug` (reusing `getAttendanceRecordByPostSlug`) and updates it in place instead of creating a second record, enforcing the "at most one record per post" invariant server-side.

## Test plan
- [x] `npx jest src/app/api/admin/attendance/__tests__/route.test.ts` — added a case asserting a repeat POST for an existing `postSlug` updates the existing record (200, same id) instead of creating a new one.
- [x] Full suite: `npx jest --coverage` — 1397 passed, 97.86% overall coverage.
- [x] `pre-commit run --all-files` — all hooks passed.
- [x] `npm run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)