### PR TITLE
fix: key attendance records by postSlug instead of a random UUID

### DIFF
--- a/src/app/api/admin/attendance/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/attendance/[id]/__tests__/route.test.ts
@@ -30,8 +30,10 @@ const mockedGetAttendanceRecord = jest.mocked(getAttendanceRecord);
 const mockedSaveAttendanceRecord = jest.mocked(saveAttendanceRecord);
 const mockedDeleteAttendanceRecord = jest.mocked(deleteAttendanceRecord);
 
+// Records are keyed by postSlug (id === postSlug - see the POST/PUT routes),
+// so the fixture's id matches its postSlug.
 const existingRecord = {
-  id: "a",
+  id: "2025-01-01-some-event",
   eventDate: "2025-01-01",
   postSlug: "2025-01-01-some-event",
   eventTitle: "Some Event",
@@ -43,10 +45,11 @@ const existingRecord = {
   updatedBy: null,
 };
 
+// A content-only edit - same post, so same id.
 const validInput = {
-  eventDate: "2025-02-01",
-  postSlug: "2025-02-01-other-event",
-  eventTitle: "Other Event",
+  eventDate: "2025-01-01",
+  postSlug: "2025-01-01-some-event",
+  eventTitle: "Some Event",
   format: "virtual" as const,
   inPersonCount: 0,
   virtualCount: 20,
@@ -57,11 +60,14 @@ function routeParams(id: string) {
 }
 
 function req(method: string, body?: unknown) {
-  return new NextRequest(`http://localhost/api/admin/attendance/a`, {
-    method,
-    headers: { "Content-Type": "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  return new NextRequest(
+    `http://localhost/api/admin/attendance/${existingRecord.id}`,
+    {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : undefined,
+    },
+  );
 }
 
 beforeEach(() => {
@@ -79,14 +85,14 @@ afterEach(() => jest.clearAllMocks());
 
 describe("GET /api/admin/attendance/[id]", () => {
   it("returns the record", async () => {
-    const res = await GET(req("GET"), routeParams("a"));
+    const res = await GET(req("GET"), routeParams(existingRecord.id));
     expect(res.status).toBe(200);
     expect((await res.json()).record).toEqual(existingRecord);
   });
 
   it("401s for an unauthorized user", async () => {
     mockedIsAuthorizedUser.mockReturnValue(false);
-    const res = await GET(req("GET"), routeParams("a"));
+    const res = await GET(req("GET"), routeParams(existingRecord.id));
     expect(res.status).toBe(401);
   });
 
@@ -103,21 +109,72 @@ describe("PUT /api/admin/attendance/[id]", () => {
       record: { ...existingRecord, ...validInput },
     });
 
-    const res = await PUT(req("PUT", validInput), routeParams("a"));
+    const res = await PUT(
+      req("PUT", validInput),
+      routeParams(existingRecord.id),
+    );
     expect(res.status).toBe(200);
     expect(mockedSaveAttendanceRecord).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "a",
+        id: existingRecord.id,
         ...validInput,
         updatedBy: "board@etsa.tech",
       }),
       existingRecord,
     );
+    expect(mockedDeleteAttendanceRecord).not.toHaveBeenCalled();
+  });
+
+  it("moves the record to the new post's key when postSlug changes, deleting the old key only after the save succeeds", async () => {
+    const renamedInput = { ...validInput, postSlug: "2025-02-01-other-event" };
+    mockedGetAttendanceRecord.mockImplementation(async (id: string) =>
+      id === existingRecord.id ? existingRecord : null,
+    );
+    mockedSaveAttendanceRecord.mockResolvedValue({
+      record: { ...existingRecord, ...renamedInput, id: renamedInput.postSlug },
+    });
+
+    const res = await PUT(
+      req("PUT", renamedInput),
+      routeParams(existingRecord.id),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSaveAttendanceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "2025-02-01-other-event",
+        ...renamedInput,
+      }),
+      null,
+    );
+    expect(mockedDeleteAttendanceRecord).toHaveBeenCalledWith(
+      existingRecord.id,
+    );
+  });
+
+  it("409s instead of clobbering another record already linked to the target post", async () => {
+    const renamedInput = { ...validInput, postSlug: "2025-02-01-other-event" };
+    const otherRecord = { ...existingRecord, id: renamedInput.postSlug };
+    mockedGetAttendanceRecord.mockImplementation(async (id: string) => {
+      if (id === existingRecord.id) return existingRecord;
+      if (id === renamedInput.postSlug) return otherRecord;
+      return null;
+    });
+
+    const res = await PUT(
+      req("PUT", renamedInput),
+      routeParams(existingRecord.id),
+    );
+    expect(res.status).toBe(409);
+    expect(mockedSaveAttendanceRecord).not.toHaveBeenCalled();
+    expect(mockedDeleteAttendanceRecord).not.toHaveBeenCalled();
   });
 
   it("401s for an unauthorized user", async () => {
     mockedIsAuthorizedUser.mockReturnValue(false);
-    const res = await PUT(req("PUT", validInput), routeParams("a"));
+    const res = await PUT(
+      req("PUT", validInput),
+      routeParams(existingRecord.id),
+    );
     expect(res.status).toBe(401);
   });
 
@@ -130,7 +187,7 @@ describe("PUT /api/admin/attendance/[id]", () => {
   it("400s for an invalid body", async () => {
     const res = await PUT(
       req("PUT", { ...validInput, inPersonCount: -1 }),
-      routeParams("a"),
+      routeParams(existingRecord.id),
     );
     expect(res.status).toBe(400);
     expect(mockedSaveAttendanceRecord).not.toHaveBeenCalled();
@@ -138,7 +195,10 @@ describe("PUT /api/admin/attendance/[id]", () => {
 
   it("500s with the underlying error when saving fails (e.g. the Sheets mirror)", async () => {
     mockedSaveAttendanceRecord.mockRejectedValue(new Error("sheets down"));
-    const res = await PUT(req("PUT", validInput), routeParams("a"));
+    const res = await PUT(
+      req("PUT", validInput),
+      routeParams(existingRecord.id),
+    );
     expect(res.status).toBe(500);
     expect((await res.json()).details).toBe("sheets down");
   });
@@ -147,20 +207,22 @@ describe("PUT /api/admin/attendance/[id]", () => {
 describe("DELETE /api/admin/attendance/[id]", () => {
   it("deletes the record by id when the Sheets webhook isn't configured", async () => {
     mockedDeleteAttendanceRecord.mockResolvedValue(undefined);
-    const res = await DELETE(req("DELETE"), routeParams("a"));
+    const res = await DELETE(req("DELETE"), routeParams(existingRecord.id));
     expect(res.status).toBe(200);
-    expect(mockedDeleteAttendanceRecord).toHaveBeenCalledWith("a");
+    expect(mockedDeleteAttendanceRecord).toHaveBeenCalledWith(
+      existingRecord.id,
+    );
   });
 
   it("401s for an unauthorized user", async () => {
     mockedIsAuthorizedUser.mockReturnValue(false);
-    const res = await DELETE(req("DELETE"), routeParams("a"));
+    const res = await DELETE(req("DELETE"), routeParams(existingRecord.id));
     expect(res.status).toBe(401);
   });
 
   it("403s when the Sheets webhook is configured (deployed), without touching the store", async () => {
     mockedIsAttendanceSheetsConfigured.mockReturnValue(true);
-    const res = await DELETE(req("DELETE"), routeParams("a"));
+    const res = await DELETE(req("DELETE"), routeParams(existingRecord.id));
     expect(res.status).toBe(403);
     expect(mockedGetAttendanceRecord).not.toHaveBeenCalled();
     expect(mockedDeleteAttendanceRecord).not.toHaveBeenCalled();
@@ -174,7 +236,7 @@ describe("DELETE /api/admin/attendance/[id]", () => {
 
   it("500s with the underlying error when deletion fails", async () => {
     mockedDeleteAttendanceRecord.mockRejectedValue(new Error("blobs down"));
-    const res = await DELETE(req("DELETE"), routeParams("a"));
+    const res = await DELETE(req("DELETE"), routeParams(existingRecord.id));
     expect(res.status).toBe(500);
     expect((await res.json()).details).toBe("blobs down");
   });

--- a/src/app/api/admin/attendance/[id]/route.ts
+++ b/src/app/api/admin/attendance/[id]/route.ts
@@ -63,17 +63,34 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     );
   }
 
+  // Records are keyed by postSlug, so re-linking this record to a different
+  // post (the picker allows that outside the locked-post view) means moving
+  // it to a new key - make sure that doesn't clobber another post's record.
+  const newId = validation.data.postSlug;
+  if (newId !== id && (await getAttendanceRecord(newId))) {
+    return NextResponse.json(
+      { error: "Another attendance record is already linked to that post" },
+      { status: 409 },
+    );
+  }
+
   try {
     const { record } = await saveAttendanceRecord(
       {
         ...existing,
         ...validation.data,
-        id,
+        id: newId,
         updatedAt: new Date().toISOString(),
         updatedBy: session!.user?.email ?? null,
       },
-      existing,
+      newId === id ? existing : null,
     );
+
+    // Only drop the old key once the new one is confirmed written, so a
+    // failed save (e.g. the Sheets mirror) leaves the original untouched.
+    if (newId !== id) {
+      await deleteAttendanceRecord(id);
+    }
 
     return NextResponse.json({ record });
   } catch (error) {

--- a/src/app/api/admin/attendance/__tests__/route.test.ts
+++ b/src/app/api/admin/attendance/__tests__/route.test.ts
@@ -20,7 +20,6 @@ jest.mock("@/lib/attendance-store", () => ({
   listAttendanceRecords: jest.fn(),
   saveAttendanceRecord: jest.fn(),
 }));
-jest.mock("node:crypto", () => ({ randomUUID: () => "generated-id" }));
 
 const mockedGetServerSession = jest.mocked(getServerSession);
 const mockedIsAuthorizedUser = jest.mocked(isAuthorizedUser);
@@ -92,27 +91,28 @@ describe("GET /api/admin/attendance", () => {
 });
 
 describe("POST /api/admin/attendance", () => {
-  it("creates a record with a generated id and the session email", async () => {
+  it("creates a record keyed by postSlug, with the session email", async () => {
     mockedSaveAttendanceRecord.mockResolvedValue({
-      record: { id: "generated-id", ...validInput } as never,
+      record: { id: validInput.postSlug, ...validInput } as never,
     });
 
     const res = await POST(postReq(validInput));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.record.id).toBe("generated-id");
+    expect(body.record.id).toBe(validInput.postSlug);
     expect(mockedSaveAttendanceRecord).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "generated-id",
+        id: validInput.postSlug,
         ...validInput,
         updatedBy: "board@etsa.tech",
       }),
+      null,
     );
   });
 
-  it("updates the existing record instead of creating a duplicate when a record for the postSlug already exists", async () => {
+  it("updates the existing record in place instead of creating a duplicate when a record for the postSlug already exists", async () => {
     const existing = {
-      id: "existing-id",
+      id: validInput.postSlug,
       ...validInput,
       inPersonCount: 1,
       createdAt: "2025-01-01T00:00:00.000Z",
@@ -127,9 +127,13 @@ describe("POST /api/admin/attendance", () => {
     const res = await POST(postReq(validInput));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.record.id).toBe("existing-id");
+    expect(body.record.id).toBe(validInput.postSlug);
     expect(mockedSaveAttendanceRecord).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "existing-id", ...validInput }),
+      expect.objectContaining({
+        id: validInput.postSlug,
+        ...validInput,
+        createdAt: existing.createdAt,
+      }),
       existing,
     );
   });

--- a/src/app/api/admin/attendance/route.ts
+++ b/src/app/api/admin/attendance/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomUUID } from "node:crypto";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { isAuthorizedUser } from "@/lib/auth-utils";
@@ -54,38 +53,27 @@ export async function POST(request: NextRequest) {
 
   try {
     const now = new Date().toISOString();
+    const id = validation.data.postSlug;
 
-    // At most one record is expected per post (see getAttendanceRecordByPostSlug) -
-    // enforce that server-side too, not just via the bulk-import UI's dedup, so a
-    // stale client (e.g. a second import run before the record list reloads) can't
-    // create a duplicate for the same event.
-    const existing = await getAttendanceRecordByPostSlug(
-      validation.data.postSlug,
+    // Records are keyed by postSlug (id === postSlug), so at most one can
+    // ever exist per post - a repeat POST for the same post (e.g. the
+    // bulk-import UI re-running against a stale record list) updates that
+    // record in place instead of creating a duplicate.
+    const existing = await getAttendanceRecordByPostSlug(id);
+
+    const { record } = await saveAttendanceRecord(
+      {
+        ...existing,
+        ...validation.data,
+        id,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+        updatedBy: session!.user?.email ?? null,
+      },
+      existing,
     );
 
-    if (existing) {
-      const { record } = await saveAttendanceRecord(
-        {
-          ...existing,
-          ...validation.data,
-          updatedAt: now,
-          updatedBy: session!.user?.email ?? null,
-        },
-        existing,
-      );
-
-      return NextResponse.json({ record });
-    }
-
-    const { record } = await saveAttendanceRecord({
-      id: randomUUID(),
-      ...validation.data,
-      createdAt: now,
-      updatedAt: now,
-      updatedBy: session!.user?.email ?? null,
-    });
-
-    return NextResponse.json({ record }, { status: 201 });
+    return NextResponse.json({ record }, { status: existing ? 200 : 201 });
   } catch (error) {
     console.error("Error creating attendance record:", error);
     return NextResponse.json(

--- a/src/lib/__tests__/attendance-store.test.ts
+++ b/src/lib/__tests__/attendance-store.test.ts
@@ -87,20 +87,20 @@ describe("getAttendanceRecord", () => {
 });
 
 describe("getAttendanceRecordByPostSlug", () => {
-  it("returns null when no record links to that post", async () => {
+  it("returns null when no record exists for that post", async () => {
     expect(await getAttendanceRecordByPostSlug("no-such-post")).toBeNull();
   });
 
-  it("returns the record whose postSlug matches", async () => {
+  it("returns the record stored under that postSlug (id === postSlug)", async () => {
     await saveAttendanceRecord(
-      makeRecord("a", "2024-01-01", { postSlug: "post-a" }),
+      makeRecord("post-a", "2024-01-01", { postSlug: "post-a" }),
     );
     await saveAttendanceRecord(
-      makeRecord("b", "2024-02-01", { postSlug: "post-b" }),
+      makeRecord("post-b", "2024-02-01", { postSlug: "post-b" }),
     );
 
     const found = await getAttendanceRecordByPostSlug("post-b");
-    expect(found?.id).toBe("b");
+    expect(found?.id).toBe("post-b");
   });
 });
 

--- a/src/lib/attendance-store.ts
+++ b/src/lib/attendance-store.ts
@@ -34,13 +34,13 @@ export async function getAttendanceRecord(
 }
 
 // Powers the per-post attendance view linked from the blog post's admin
-// actions - at most one record is expected per post, so the first match
-// (if any) is returned.
+// actions. Records are keyed in Blobs by postSlug (id === postSlug - see the
+// /api/admin/attendance routes, which own that invariant), so this is a
+// direct lookup rather than a list+filter.
 export async function getAttendanceRecordByPostSlug(
   postSlug: string,
 ): Promise<AttendanceRecord | null> {
-  const records = await listAttendanceRecords();
-  return records.find((record) => record.postSlug === postSlug) ?? null;
+  return getAttendanceRecord(postSlug);
 }
 
 // When the Sheets webhook isn't configured, we're in local development (see


### PR DESCRIPTION
## Summary
Follow-up to #454. Attendance records were keyed in Netlify Blobs by a random UUID, so the "one record per post" invariant was only enforced by application code (the check added in #454), not by storage itself.

- Records are now keyed by `postSlug` directly (`id === postSlug`).
- `getAttendanceRecordByPostSlug` is now a direct `store.get` instead of listing every record and filtering.
- `POST /api/admin/attendance` keys new records by `postSlug`; a repeat POST for the same post updates that record in place (200) instead of creating a duplicate (previously 201-always).
- `PUT /api/admin/attendance/[id]` handles re-linking a record to a different post (the generic edit form allows changing the linked post) by moving it to the new post's key, 409ing if that post already has its own record, and only deleting the old key after the new one is confirmed written - so a failed save (e.g. Sheets mirror) leaves the original untouched.

No migration for existing data - the existing records are effectively test/seed data, so the local dev Blobs store for `attendance` was cleared instead. Equivalent cleanup is needed wherever this is deployed.

## Test plan
- [x] `npx jest src/app/api/admin/attendance src/lib/__tests__/attendance-store.test.ts` - added coverage for: create-by-slug, update-in-place on repeat POST, PUT content-only edit (id unchanged), PUT re-link to a new post (key move + old key deleted only after success), and 409 on a re-link that would clobber another post's record.
- [x] Full suite: `npx jest --coverage` - 1399 passed, 97.84% overall coverage.
- [x] `pre-commit run --all-files` - all hooks passed.
- [x] `npm run build` - succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)