### PR TITLE
fix: verify attendance Sheets writes actually land, not just report success

### DIFF
--- a/docs/attendance-sheets-setup.md
+++ b/docs/attendance-sheets-setup.md
@@ -19,7 +19,20 @@ When `ATTENDANCE_SHEETS_WEBHOOK_URL` is configured, a create/edit in
 succeeds if **both** succeed - if this webhook fails, the Blobs write is
 rolled back (the new record is deleted, or an edited record is restored to
 its previous value) and the admin request fails, so the two stores can't
-drift apart. When it **isn't** configured (local development - see
+drift apart. "Succeeds" isn't just a 200 from `doPost` - the app also reads
+the row back via `doGet(?id=...)` and checks the counts match
+(`verifyAttendanceRecordInSheets` in `src/lib/attendance-sheets-sync.ts`),
+because bulk import fires many creates/edits concurrently and an unlocked
+Apps Script write can silently drop or clobber a row while still reporting
+success. The `LockService` call in `doPost` below and the `doGet(?id=...)`
+lookup exist specifically for that: the lock stops the collision from
+happening, the read-back catches it if it somehow still does. **Both
+pieces are required together** - the read-back can't do its job against an
+older deployment of this script that doesn't have `doGet(?id=...)` (every
+save's verification step will fail), and the lock alone doesn't give the
+app a way to confirm the write actually landed.
+
+When it **isn't** configured (local development - see
 `isAttendanceSheetsConfigured` in `src/lib/attendance-sheets-sync.ts`), a
 create/edit skips the Sheets call entirely and just writes to Blobs, so
 local testing never needs a real webhook and never fails because one isn't
@@ -79,6 +92,23 @@ function getAttendanceSheet() {
 }
 
 function doPost(e) {
+  // Bulk import can fire many creates/edits concurrently. Without a lock,
+  // two requests can both read "no existing row for this id" and both
+  // append, or one can overwrite the other's write mid-flight - the script
+  // would still report success either way, so the app-side caller (see
+  // verifyAttendanceRecordInSheets in src/lib/attendance-sheets-sync.ts)
+  // can't tell from the response alone. The lock makes each request's
+  // find-then-write atomic relative to the others.
+  const lock = LockService.getScriptLock();
+  try {
+    lock.waitLock(10000);
+  } catch {
+    return jsonResponse({
+      success: false,
+      error: "Could not acquire lock - too many concurrent writes",
+    });
+  }
+
   try {
     const sheet = getAttendanceSheet();
     const data = JSON.parse(e.postData.contents);
@@ -108,17 +138,57 @@ function doPost(e) {
       sheet.getRange(rowIndex, 1, 1, rowData.length).setValues([rowData]);
     }
 
+    SpreadsheetApp.flush();
     return jsonResponse({ success: true });
   } catch (error) {
     console.error("Error processing attendance sync:", error);
     return jsonResponse({ success: false, error: error.toString() });
+  } finally {
+    lock.releaseLock();
   }
 }
 
-function doGet() {
-  return ContentService.createTextOutput(
-    "ETSA Attendance webhook is running - " + new Date().toISOString(),
-  ).setMimeType(ContentService.MimeType.TEXT);
+// No `id` param: health check (used to confirm the deployment is live).
+// With `id`: looks up that row - used by verifyAttendanceRecordInSheets to
+// confirm a write actually landed, since doPost reporting success doesn't
+// guarantee that on its own (see the lock comment above).
+function doGet(e) {
+  const id = e.parameter && e.parameter.id;
+
+  if (!id) {
+    return ContentService.createTextOutput(
+      "ETSA Attendance webhook is running - " + new Date().toISOString(),
+    ).setMimeType(ContentService.MimeType.TEXT);
+  }
+
+  try {
+    const sheet = getAttendanceSheet();
+    const rowIndex = findRowById(sheet, id);
+
+    if (rowIndex === -1) {
+      return jsonResponse({ found: false });
+    }
+
+    const values = sheet.getRange(rowIndex, 1, 1, 10).getValues()[0];
+    return jsonResponse({
+      found: true,
+      row: {
+        id: values[0],
+        eventDate: values[1],
+        postSlug: values[2],
+        eventTitle: values[3],
+        format: values[4],
+        inPersonCount: values[5],
+        virtualCount: values[6],
+        notes: values[7],
+        updatedAt: values[8],
+        updatedBy: values[9],
+      },
+    });
+  } catch (error) {
+    console.error("Error reading attendance row:", error);
+    return jsonResponse({ found: false, error: error.toString() });
+  }
 }
 
 function findRowById(sheet, id) {
@@ -137,6 +207,16 @@ function jsonResponse(payload) {
 ```
 
 ## Step 3: Deploy
+
+> **Already have this webhook deployed?** The `LockService` locking and the
+> `doGet(?id=...)` row lookup above are required by the app's verification
+> step (see Overview) - an older deployment without them will fail
+> verification on **every** save, since `syncAttendanceRecordToSheets`
+> always calls `doGet(?id=...)` after posting. Update the script and
+> redeploy it (**Deploy → Manage deployments → edit the existing
+> deployment → New version**, which keeps the same web app URL, so
+> `ATTENDANCE_SHEETS_WEBHOOK_URL` doesn't need to change) **before** the
+> updated app code ships - not after.
 
 Same as the RSVP webhook (see
 [docs/google-apps-script-setup.md](./google-apps-script-setup.md#step-5-deploy-as-web-app)):
@@ -170,3 +250,14 @@ curl -X POST "YOUR_WEBHOOK_URL" \
 Should add or update a row keyed on `id`. Re-run with different counts and
 the same `id` to confirm it updates the existing row rather than appending a
 new one.
+
+Then confirm the read-back the app relies on for verification:
+
+```bash
+curl "YOUR_WEBHOOK_URL?id=test-id"
+```
+
+Should return `{"found":true,"row":{...}}` with the counts from the last
+POST. `curl "YOUR_WEBHOOK_URL?id=no-such-id"` should return
+`{"found":false}`, and `curl "YOUR_WEBHOOK_URL"` (no `id`) should still
+return the plain-text health check.

--- a/src/lib/__tests__/attendance-sheets-sync.test.ts
+++ b/src/lib/__tests__/attendance-sheets-sync.test.ts
@@ -20,15 +20,28 @@ const record: AttendanceRecord = {
   updatedBy: "a@etsa.tech",
 };
 
+const verifiedRow = {
+  found: true,
+  row: {
+    inPersonCount: record.inPersonCount,
+    virtualCount: record.virtualCount,
+  },
+};
+
 beforeEach(() => {
   process.env = {
     ...originalEnv,
     ATTENDANCE_SHEETS_WEBHOOK_URL: "https://script.example/attendance",
   };
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    json: async () => ({}),
-  }) as unknown as typeof fetch;
+  // First call is the doPost write, second is the doGet(?id=) verification
+  // read-back - both need to resolve for a plain "happy path" test.
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    .mockResolvedValue({
+      ok: true,
+      json: async () => verifiedRow,
+    }) as unknown as typeof fetch;
 });
 
 afterEach(() => {
@@ -49,7 +62,7 @@ describe("isAttendanceSheetsConfigured", () => {
 });
 
 describe("syncAttendanceRecordToSheets", () => {
-  it("posts the record fields to the webhook", async () => {
+  it("posts the record fields to the webhook, then verifies by reading the row back", async () => {
     await syncAttendanceRecordToSheets(record);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://script.example/attendance",
@@ -57,6 +70,11 @@ describe("syncAttendanceRecordToSheets", () => {
     );
     const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
     expect(body).toEqual(record);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://script.example/attendance?id=${record.id}`,
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 
   it("throws when the webhook URL isn't configured", async () => {
@@ -82,6 +100,58 @@ describe("syncAttendanceRecordToSheets", () => {
     }) as unknown as typeof fetch;
     await expect(syncAttendanceRecordToSheets(record)).rejects.toThrow(
       "bad row",
+    );
+  });
+
+  it("throws when verification can't find the row (e.g. an older deployment without doGet(?id=))", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ found: false }),
+      }) as unknown as typeof fetch;
+    await expect(syncAttendanceRecordToSheets(record)).rejects.toThrow(
+      "row not found after write",
+    );
+  });
+
+  it("throws when the verified row's counts don't match (concurrent write collision)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          found: true,
+          row: { inPersonCount: 999, virtualCount: record.virtualCount },
+        }),
+      }) as unknown as typeof fetch;
+    await expect(syncAttendanceRecordToSheets(record)).rejects.toThrow(
+      "doesn't match",
+    );
+  });
+
+  it("throws when found: true is missing its row payload", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ found: true }),
+      }) as unknown as typeof fetch;
+    await expect(syncAttendanceRecordToSheets(record)).rejects.toThrow(
+      "doesn't match",
+    );
+  });
+
+  it("throws when the verification read-back returns a non-ok response", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+    await expect(syncAttendanceRecordToSheets(record)).rejects.toThrow(
+      "Attendance Sheets verification returned 500",
     );
   });
 });

--- a/src/lib/attendance-sheets-sync.ts
+++ b/src/lib/attendance-sheets-sync.ts
@@ -12,6 +12,19 @@ export function isAttendanceSheetsConfigured(): boolean {
   return Boolean(process.env.ATTENDANCE_SHEETS_WEBHOOK_URL);
 }
 
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 // Mirrors attendance record creates/edits to a Google Sheet via an Apps
 // Script webhook, separate from GOOGLE_SHEETS_WEBHOOK_URL (the RSVP form's
 // webhook, which writes to a different sheet). See
@@ -29,26 +42,61 @@ export async function syncAttendanceRecordToSheets(
     throw new Error("Attendance Sheets webhook URL not configured");
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  const response = await fetchWithTimeout(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(record),
+  });
 
-  try {
-    const response = await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(record),
-      signal: controller.signal,
-    });
+  if (!response.ok) {
+    throw new Error(`Attendance Sheets webhook returned ${response.status}`);
+  }
 
-    if (!response.ok) {
-      throw new Error(`Attendance Sheets webhook returned ${response.status}`);
-    }
+  const result = await response.json();
+  if (result?.error) {
+    throw new Error(result.error);
+  }
 
-    const result = await response.json();
-    if (result?.error) {
-      throw new Error(result.error);
-    }
-  } finally {
-    clearTimeout(timeoutId);
+  await verifyAttendanceRecordInSheets(record, webhookUrl);
+}
+
+// The webhook can report success even when the write didn't actually land -
+// e.g. concurrent bulk-import requests racing on the Apps Script's
+// read-then-write (find existing row, then append/overwrite) without
+// locking can silently drop or clobber a row while every request still gets
+// a 200 back. Read the row back by id and check the counts that actually
+// matter, so a collision like that fails loudly here - which rolls back the
+// Blobs write via saveAttendanceRecord - instead of Blobs and the Sheet
+// silently diverging. Requires the Apps Script's doGet(?id=) handler from
+// docs/attendance-sheets-setup.md; an older deployment without it will fail
+// verification for every save, so that script must be redeployed first.
+async function verifyAttendanceRecordInSheets(
+  record: AttendanceRecord,
+  webhookUrl: string,
+): Promise<void> {
+  const url = `${webhookUrl}?id=${encodeURIComponent(record.id)}`;
+  const response = await fetchWithTimeout(url, { method: "GET" });
+
+  if (!response.ok) {
+    throw new Error(
+      `Attendance Sheets verification returned ${response.status}`,
+    );
+  }
+
+  const result = await response.json();
+  if (!result?.found) {
+    throw new Error(
+      "Attendance Sheets verification: row not found after write",
+    );
+  }
+
+  const row = result.row ?? {};
+  if (
+    Number(row.inPersonCount) !== record.inPersonCount ||
+    Number(row.virtualCount) !== record.virtualCount
+  ) {
+    throw new Error(
+      "Attendance Sheets verification: written row doesn't match (possible concurrent write collision)",
+    );
   }
 }


### PR DESCRIPTION
## Summary
Bulk import fires every row's create/edit concurrently, and the deployed Apps Script's `doPost` does an unlocked read-then-write (find existing row by id, then append/overwrite). Concurrent invocations can race - two requests both see "no row yet" and both append, or one clobbers the other mid-write - and the script still reports `{success: true}` either way. `syncAttendanceRecordToSheets` trusted that response, so no rollback fired: the Blobs write stood while the Sheet silently lost or corrupted a row. This matches the observed symptom of records reliably landing in Blobs but not always in the Sheet.

- **`docs/attendance-sheets-setup.md`**: `doPost` now wraps its find-then-write in `LockService.getScriptLock()` so concurrent requests serialize instead of racing. Added `doGet(?id=...)` to read a row back by id (`doGet` with no `id` is unchanged - still the plain-text health check).
- **`attendance-sheets-sync.ts`**: after `doPost` reports success, `verifyAttendanceRecordInSheets` reads the row back via `doGet(?id=...)` and checks `inPersonCount`/`virtualCount` match what was just sent - throwing (which triggers `saveAttendanceRecord`'s existing Blobs rollback) if the row is missing or the counts don't match.

## ⚠️ Deployment order
The Apps Script **must be redeployed with the new `doGet(?id=...)` handler before this app code ships** - verification always calls `doGet(?id=...)` after posting, so an older deployment without it will fail verification on **every** save. Updating the existing deployment (Manage deployments → edit → New version) keeps the same web app URL, so `ATTENDANCE_SHEETS_WEBHOOK_URL` doesn't need to change. Full instructions + a `curl` smoke test are in the updated doc.

## Test plan
- [x] `npx jest src/lib/__tests__/attendance-sheets-sync.test.ts` - added coverage for: verification read-back happy path, row-not-found, counts-mismatch (collision), missing row payload, and non-ok verification response.
- [x] Full suite: `npx jest --coverage` - 1402 passed, 97.84% overall coverage.
- [x] `pre-commit run --all-files` - all hooks passed.
- [x] `npm run build` - succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)