### PR TITLE
fix: render the public attendance page via ISR instead of at build time

### DIFF
--- a/src/app/attendance/__tests__/page.test.tsx
+++ b/src/app/attendance/__tests__/page.test.tsx
@@ -38,7 +38,7 @@ describe("AttendancePage (public)", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
-  it("falls back to an empty data set when Blobs isn't reachable at build time", async () => {
+  it("falls back to an empty data set when Blobs isn't reachable", async () => {
     mockedListAttendanceRecords.mockRejectedValue(
       new Error("no blobs context"),
     );

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -2,11 +2,14 @@ import { listAttendanceRecords } from "@/lib/attendance-store";
 import { computeAttendanceStats } from "@/lib/attendance-stats";
 import { AttendanceStats } from "@/components/AttendanceStats";
 
-// Static export - regenerates on the next site build/deploy, same
-// staleness model the rest of the public site already has for git-based
-// content. Deliberately renders only aggregates (see
-// src/app/api/attendance/stats/route.ts), never a per-event table.
-export const dynamic = "force-static";
+// Rendered per-request, not statically - Netlify Blobs' automatic context
+// (siteID/token) is only available to a live Function invocation, not the
+// `next build` step that would run this page's data fetch under
+// force-static (confirmed by the MissingBlobsEnvironmentError that static
+// mode threw in production). Deliberately renders only aggregates (see
+// src/app/api/attendance/stats/route.ts, the same read this page does),
+// never a per-event table.
+export const dynamic = "force-dynamic";
 
 export const metadata = {
   title: "Attendance - ETSA",
@@ -15,15 +18,14 @@ export const metadata = {
 };
 
 export default async function AttendancePage() {
-  // Blobs needs a live Netlify site context (siteID/token), which is only
-  // present during an actual Netlify build/deploy - not a plain local
-  // `next build`. Fall back to an empty data set rather than crashing static
-  // generation when that context isn't available.
+  // Local `next build`/`next dev` (outside an actual Netlify Function
+  // invocation) still has no Blobs context - fall back to an empty data set
+  // rather than crashing the page when that's the case.
   let records: Awaited<ReturnType<typeof listAttendanceRecords>> = [];
   try {
     records = await listAttendanceRecords();
   } catch (error) {
-    console.error("Error loading attendance records for static page:", error);
+    console.error("Error loading attendance records:", error);
   }
   const stats = computeAttendanceStats(records);
 

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -2,14 +2,22 @@ import { listAttendanceRecords } from "@/lib/attendance-store";
 import { computeAttendanceStats } from "@/lib/attendance-stats";
 import { AttendanceStats } from "@/components/AttendanceStats";
 
-// Rendered per-request, not statically - Netlify Blobs' automatic context
-// (siteID/token) is only available to a live Function invocation, not the
-// `next build` step that would run this page's data fetch under
-// force-static (confirmed by the MissingBlobsEnvironmentError that static
-// mode threw in production). Deliberately renders only aggregates (see
+// ISR, not force-static - Netlify Blobs' automatic context (siteID/token)
+// is only available to a live Function invocation, not the `next build`
+// step that force-static would run this page's data fetch under (confirmed
+// by the MissingBlobsEnvironmentError that threw in production, and by the
+// same error still showing up in a plain local `next build` below - the
+// try/catch's empty-data fallback is what that build bakes in). The
+// difference from force-static is that this page doesn't stay wrong forever:
+// once this window elapses, the next request triggers a background
+// regeneration inside a real Function invocation - where Blobs works - and
+// that refreshed result is what gets cached and served after that. So this
+// is still a cached/static page for nearly all traffic, not a Function call
+// per visit, while self-healing within a day of an admin edit instead of
+// needing a rebuild. Renders only aggregates (see
 // src/app/api/attendance/stats/route.ts, the same read this page does),
 // never a per-event table.
-export const dynamic = "force-dynamic";
+export const revalidate = 86400; // 1 day
 
 export const metadata = {
   title: "Attendance - ETSA",


### PR DESCRIPTION
## Summary
`/attendance` used `force-static`, so `listAttendanceRecords()` only ever ran during `next build`. Netlify Blobs' automatic context (siteID/token) is only available to a live Function invocation, not that build step, so the fetch always threw `MissingBlobsEnvironmentError`. The page's `try/catch` swallowed it and rendered all-zero stats - silently and permanently, no matter how much real data existed. Confirmed in production: the admin portal shows real attendance records, but https://etsa.tech/attendance still reads zero.

- `src/app/attendance/page.tsx`: `dynamic = "force-static"` replaced with `export const revalidate = 86400` (1 day) - ISR instead of either static extreme. The page stays cached/static for nearly all traffic (no Function call per visit, unlike `force-dynamic`), but unlike `force-static` it doesn't stay wrong forever: once the window elapses, the next request triggers a background regeneration inside a real Function invocation - where Blobs works - refreshing the cached result. Deploys are monthly and attendance data only changes via admin edits/bulk-import, so a day of staleness between an edit and the page picking it up is an acceptable tradeoff for avoiding a Function call on every visit.

## Test plan
- [x] `npx jest src/app/attendance` - updated the existing "falls back to an empty data set" test's description (behavior unchanged, still covers the no-Blobs-context fallback).
- [x] Full suite: `npx jest --coverage` - 1403 passed, 97.84% overall coverage.
- [x] `pre-commit run --all-files` - all hooks passed.
- [x] `npm run build` - `/attendance` shows `○` with `Revalidate: 1d` in the route table (confirmed after fixing a transcription slip where this was briefly 7 days instead of 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)